### PR TITLE
Device name can be null, added a fallback to address or "unknown" string

### DIFF
--- a/bose-macos-utility/bose-macos-utility/AppDelegate.swift
+++ b/bose-macos-utility/bose-macos-utility/AppDelegate.swift
@@ -118,11 +118,11 @@ extension AppDelegate {
         
         // Set up the initial menus
         devices.forEach { device in
-            let deviceItem = NSMenuItem(title: device.name,
+            let deviceItem = NSMenuItem(title: device.nameOrAddress ?? "unknown",
                                         action: #selector(deviceSelected(sender:)),
                                         keyEquivalent: "")
             deviceItem.indentationLevel = 1
-            deviceItem.title = device.name
+            deviceItem.title = device.nameOrAddress ?? "unknown"
             self.selectDeviceMenu.addItem(deviceItem)
         }
     }


### PR DESCRIPTION
At the moment the application can crash if one of the found devices don't have a name, because there is no check for null/nil.